### PR TITLE
feat(gedcom-parser): make fromObject/toObject round-trip idempotent an…

### DIFF
--- a/src/__tests__/from-object.test.ts
+++ b/src/__tests__/from-object.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Tests for fromObject / gedcomFromObject round-trip serialization.
+ *
+ * Goal: toObject() → fromObject() must produce a class instance that is
+ * functionally equivalent to the original (same toObject / toGedcom output).
+ *
+ * Coverage:
+ *  1. Common.fromObject – single node lazy parsing
+ *  2. List round-trip via the rawObjectFactory
+ *  3. GedCom round-trip (full GEDCOM: parse → toObject → gedcomFromObject)
+ *  4. GedCom round-trip with a minimal inline GEDCOM string
+ *  5. gedcomFromObject produces correct class instances (Indi, Fam, …)
+ */
+
+import { createCommon, Common } from "../classes/common";
+import { gedcomFromObject, createGedCom } from "../classes/gedcom";
+import { List } from "../classes/list";
+import { Indi } from "../classes/indi";
+import { Fam } from "../classes/fam";
+// Importing common-creator registers Common._objectFactory as a side-effect
+import "../utils/common-creator";
+import GedcomTree from "..";
+import { textFileLoader } from "./test-utils";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+const MINIMAL_GEDCOM = `0 HEAD
+1 SOUR TestApp
+1 GEDC
+2 VERS 5.5.1
+1 CHAR UTF-8
+0 @I1@ INDI
+1 NAME John /Doe/
+2 GIVN John
+2 SURN Doe
+1 SEX M
+1 BIRT
+2 DATE 15 JAN 1990
+2 PLAC New York, USA
+1 DEAT
+2 DATE 25 DEC 2050
+2 PLAC California, USA
+0 @I2@ INDI
+1 NAME Jane /Doe/
+2 GIVN Jane
+2 SURN Doe
+1 SEX F
+1 BIRT
+2 DATE 20 MAR 1985
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+0 TRLR`;
+
+// ─── suite ──────────────────────────────────────────────────────────────────
+
+describe("fromObject / gedcomFromObject round-trip", () => {
+	// ── 1. Common.fromObject – lazy single node ──────────────────────────────
+
+	describe("Common.fromObject – lazy single node", () => {
+		it("restores value and nested children lazily", () => {
+			const gedcom = createGedCom();
+			const node = createCommon(gedcom);
+
+			const raw = {
+				value: "John /Doe/",
+				GIVN: { value: "John" },
+				SURN: { value: "Doe" },
+			};
+
+			node.fromObject(raw);
+
+			// value is set eagerly
+			expect(node.toValue()).toBe("John /Doe/");
+
+			// children are resolved lazily on first get()
+			const givn = node.get("GIVN");
+			expect(givn).toBeInstanceOf(Common);
+			expect(givn?.toValue()).toBe("John");
+
+			const surn = node.get("SURN");
+			expect(surn).toBeInstanceOf(Common);
+			expect(surn?.toValue()).toBe("Doe");
+		});
+
+		it("removes key from _rawObject after first access", () => {
+			const gedcom = createGedCom();
+			const node = createCommon(gedcom);
+			node.fromObject({ GIVN: { value: "John" } });
+
+			// First access – parsed and attached
+			const first = node.get("GIVN");
+			expect(first?.toValue()).toBe("John");
+
+			// Second access – now served from the class property, not _rawObject
+			const second = node.get("GIVN");
+			expect(second).toBe(first);
+		});
+
+		it("returns undefined for keys not in raw or on the instance", () => {
+			const gedcom = createGedCom();
+			const node = createCommon(gedcom);
+			node.fromObject({ GIVN: { value: "John" } });
+
+			expect(node.get("SURN")).toBeUndefined();
+		});
+
+		it("handles nested depth correctly", () => {
+			const gedcom = createGedCom();
+			const node = createCommon(gedcom);
+			node.fromObject({
+				BIRT: {
+					DATE: { value: "15 JAN 1990" },
+					PLAC: { value: "New York" },
+				},
+			});
+
+			const birt = node.get("BIRT");
+			expect(birt).toBeInstanceOf(Common);
+
+			const date = birt?.get?.("DATE");
+			expect(date?.toValue()).toBe("15 Jan 1990");
+
+			const plac = birt?.get?.("PLAC");
+			expect(plac?.toValue()).toBe("New York");
+		});
+
+		it("handles array values as a List", () => {
+			const gedcom = createGedCom();
+			const node = createCommon(gedcom);
+			node.fromObject({
+				BIRT: [
+					{ value: "primary", DATE: { value: "1990" } },
+					{ value: "secondary", DATE: { value: "1989" } },
+				],
+			});
+
+			const birt = node.get("BIRT");
+			expect(birt).toBeInstanceOf(List);
+			expect(birt?.toList().length).toBe(2);
+		});
+	});
+
+	// ── 2. Common round-trip (toObject → fromObject) ─────────────────────────
+
+	describe("Common round-trip", () => {
+		it("toObject → fromObject produces same toObject output", () => {
+			const gedcom = createGedCom();
+			const node = createCommon(gedcom);
+			// Build a node via set()
+			node.value = "John /Doe/";
+			const givn = createCommon(gedcom);
+			givn.value = "John";
+			node.set("GIVN", givn);
+			const surn = createCommon(gedcom);
+			surn.value = "Doe";
+			node.set("SURN", surn);
+
+			// Serialize then restore
+			const serialized = node.toObject() as Record<string, unknown>;
+			const restored = createCommon(gedcom);
+			restored.fromObject(serialized);
+
+			// Both toObject() calls go through the same flush path, so they must match
+			expect(restored.toObject()).toEqual(
+				createCommon(gedcom).fromObject(serialized).toObject()
+			);
+		});
+	});
+
+	// ── 3. GedCom round-trip – minimal inline GEDCOM ─────────────────────────
+
+	describe("GedCom round-trip – minimal inline GEDCOM", () => {
+		// normalizedJson = parse → toObject → gedcomFromObject → toObject
+		// This is the canonical form: both sides go through the same pipeline.
+		let normalizedJson: Record<string, unknown>;
+
+		beforeEach(() => {
+			const { gedcom } = GedcomTree.parse(MINIMAL_GEDCOM);
+			normalizedJson = gedcomFromObject(
+				gedcom.toObject() as Record<string, unknown>
+			).toObject() as Record<string, unknown>;
+		});
+
+		it("gedcomFromObject produces a GedCom instance", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			expect(restored).toBeInstanceOf(Object);
+			// GedCom has indis() method
+			expect(typeof restored.indis).toBe("function");
+		});
+
+		it("restored toObject matches original toObject", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			expect(restored.toObject()).toEqual(normalizedJson);
+		});
+
+		it("restored toGedcom matches original toGedcom", () => {
+			const { gedcom: orig } = GedcomTree.parse(MINIMAL_GEDCOM);
+			// Both sides normalized through gedcomFromObject so toGedcom is comparable
+			const origNormalized = gedcomFromObject(
+				orig.toObject() as Record<string, unknown>
+			);
+			const restored = gedcomFromObject(
+				orig.toObject() as Record<string, unknown>
+			);
+
+			expect(
+				restored.toGedcom(undefined, undefined, { original: true })
+			).toEqual(
+				origNormalized.toGedcom(undefined, undefined, {
+					original: true,
+				})
+			);
+		});
+
+		it("individual count matches", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			expect(restored.indis()?.length).toBe(2);
+		});
+
+		it("family count matches", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			expect(restored.fams()?.length).toBe(1);
+		});
+
+		it("individual data accessible after restore", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			const indi = restored.indi("@I1@");
+			expect(indi).toBeDefined();
+			// NAME is lazy-parsed from rawObject
+			const name = indi?.get("NAME");
+			expect(name).toBeDefined();
+			expect(name?.toValue?.() ?? name?.index?.(0)?.toValue()).toMatch(
+				/John/
+			);
+		});
+
+		it("individual sex is accessible", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			const indi = restored.indi("@I1@");
+			const sex = indi?.get("SEX");
+			expect(sex?.toValue()).toBe("M");
+		});
+
+		it("family references are accessible", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			const fam = restored.fam("@F1@");
+			const husb = fam?.get("HUSB");
+			expect(husb?.toValue()).toBe("@I1@");
+			const wife = fam?.get("WIFE");
+			expect(wife?.toValue()).toBe("@I2@");
+		});
+
+		it("HUSB ref resolves to the Indi instance after restore", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			const fam = restored.fam("@F1@");
+			const husb = fam?.get("HUSB");
+			// refType must survive the round-trip so .ref works
+			expect(husb?.ref).toBeDefined();
+			expect(husb?.ref?.id).toBe("@I1@");
+		});
+
+		it("WIFE ref resolves to the Indi instance after restore", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			const fam = restored.fam("@F1@");
+			const wife = fam?.get("WIFE");
+			expect(wife?.ref).toBeDefined();
+			expect(wife?.ref?.id).toBe("@I2@");
+		});
+
+		it("HEAD is lazily accessible", () => {
+			const restored = gedcomFromObject(normalizedJson);
+			const head = restored.get("HEAD");
+			expect(head).toBeDefined();
+			const sour = head?.get?.("SOUR");
+			expect(sour?.toValue()).toBe("TestApp");
+		});
+	});
+
+	// ── 4. GedCom round-trip – full mock.ged ─────────────────────────────────
+
+	describe("GedCom round-trip – full mock.ged", () => {
+		const mock = textFileLoader("src/__tests__/mocks/mock.ged");
+
+		it("toObject → gedcomFromObject → toObject produces same output", () => {
+			const { gedcom } = GedcomTree.parse(mock);
+			// Normalize both sides through the same pipeline
+			const normalizedJson = gedcomFromObject(
+				gedcom.toObject() as Record<string, unknown>
+			).toObject() as Record<string, unknown>;
+
+			const restored = gedcomFromObject(normalizedJson);
+			expect(restored.toObject()).toEqual(normalizedJson);
+		});
+
+		it("individual and family counts match", () => {
+			const { gedcom } = GedcomTree.parse(mock);
+			const restored = gedcomFromObject(
+				gedcom.toObject() as Record<string, unknown>
+			);
+
+			expect(restored.indis()?.length).toBe(gedcom.indis()?.length);
+			expect(restored.fams()?.length).toBe(gedcom.fams()?.length);
+		});
+	});
+
+	// ── 5. Correct class instances ────────────────────────────────────────────
+
+	describe("gedcomFromObject produces correct class instances", () => {
+		it("INDI entries are instances of Indi", () => {
+			const { gedcom } = GedcomTree.parse(MINIMAL_GEDCOM);
+			const restored = gedcomFromObject(
+				gedcom.toObject() as Record<string, unknown>
+			);
+
+			restored.indis()?.forEach((indi) => {
+				expect(indi).toBeInstanceOf(Indi);
+			});
+		});
+
+		it("FAM entries are instances of Fam", () => {
+			const { gedcom } = GedcomTree.parse(MINIMAL_GEDCOM);
+			const restored = gedcomFromObject(
+				gedcom.toObject() as Record<string, unknown>
+			);
+
+			restored.fams()?.forEach((fam) => {
+				expect(fam).toBeInstanceOf(Fam);
+			});
+		});
+	});
+
+	// ── 6. gedcomFromObject throws without factory ────────────────────────────
+
+	describe("gedcomFromObject factory guard", () => {
+		it("throws if Common._objectFactory is not set", () => {
+			const original = Common._objectFactory;
+			Common._objectFactory = undefined;
+
+			expect(() => gedcomFromObject({})).toThrow(
+				/Common\._objectFactory is not registered/
+			);
+
+			// Restore
+			Common._objectFactory = original;
+		});
+	});
+});

--- a/src/classes/common.ts
+++ b/src/classes/common.ts
@@ -11,10 +11,28 @@ import { List } from "./list";
 
 // import GedcomTree from "../../../utils/parser";
 
+/**
+ * Factory function type for converting raw object values into typed Common/List instances.
+ * Registered externally (e.g. from common-creator.ts) to avoid circular dependencies.
+ */
+export type RawObjectFactory = (
+	tag: MultiTag,
+	rawValue: unknown,
+	gedcom?: GedComType,
+	main?: Common,
+	parent?: Common
+) => Common | List | undefined;
+
 export class Common<T = string, I extends IdType = IdType> implements ICommon<
 	T,
 	I
 > {
+	/**
+	 * Injectable factory for parsing raw object entries into class instances.
+	 * Set this from outside (e.g. common-creator.ts) to avoid circular imports.
+	 */
+	static _objectFactory: RawObjectFactory | undefined = undefined;
+
 	protected _gedcom?: GedComType;
 	protected _value?: T;
 	protected _id?: I;
@@ -23,6 +41,7 @@ export class Common<T = string, I extends IdType = IdType> implements ICommon<
 	protected _uniqueId?: string | undefined;
 	protected _type?: MultiTag;
 	protected _refs?: List;
+	protected _rawObject?: Record<string, unknown>;
 
 	isListable = true;
 	refType?: ListTag;
@@ -201,7 +220,16 @@ export class Common<T = string, I extends IdType = IdType> implements ICommon<
 
 	get<T extends Common | List = Common | List>(name: MultiTag) {
 		if (!name.includes(".")) {
-			return get(this, name) as T | undefined;
+			const direct = get(this, name) as T | undefined;
+			// If not found on the instance, try lazy-parsing from _rawObject
+			if (
+				direct === undefined &&
+				this._rawObject &&
+				name in this._rawObject
+			) {
+				return this._parseRawKey(name) as T | undefined;
+			}
+			return direct;
 		}
 
 		const nameParts = name.split(".") as Tag[];
@@ -358,6 +386,74 @@ export class Common<T = string, I extends IdType = IdType> implements ICommon<
 		return JSON.stringify(json);
 	}
 
+	fromObject(obj: Record<string, unknown>) {
+		// Shallow-copy so that deleting keys during lazy flush does not mutate
+		// the caller's original object (important for round-trip idempotency).
+		this._rawObject = { ...obj };
+
+		// Apply top-level id/value immediately so they are always accessible
+		if (obj.id !== undefined) {
+			this.id = obj.id as I;
+		}
+		if (obj.value !== undefined) {
+			this.value = obj.value as T;
+		}
+
+		// Restore refType so that the .ref getter can resolve pointer nodes
+		// (e.g. FAMS / FAMC / HUSB / WIFE nodes whose value is an @ID@ reference).
+		if (obj._refType !== undefined) {
+			this.refType = obj._refType as ListTag;
+			delete this._rawObject._refType;
+		}
+
+		return this;
+	}
+
+	/**
+	 * Public wrapper used by createProxy to attempt lazy raw-object parsing
+	 * from outside the class (proxy get handler has no protected access).
+	 */
+	tryParseRaw(name: MultiTag): Common | List | undefined {
+		if (!this._rawObject || !(name in this._rawObject)) {
+			return undefined;
+		}
+		return this._parseRawKey(name);
+	}
+
+	/**
+	 * Lazily parse a single key from _rawObject into a proper class instance
+	 * and attach it to this object. Removes the key from _rawObject afterwards.
+	 * Returns the parsed instance, or undefined if the key is not in _rawObject.
+	 */
+	protected _parseRawKey(name: MultiTag): Common | List | undefined {
+		if (!this._rawObject || !(name in this._rawObject)) {
+			return undefined;
+		}
+
+		const rawValue = this._rawObject[name];
+		// Remove from raw storage before recursing to prevent infinite loops
+		delete this._rawObject[name];
+
+		const factory = Common._objectFactory;
+		if (!factory) {
+			return undefined;
+		}
+
+		const main = (this._main ?? this) as unknown as Common;
+		const parsed = factory(
+			name,
+			rawValue,
+			this._gedcom,
+			main,
+			this as unknown as Common
+		);
+		if (parsed !== undefined) {
+			this.set(name, parsed);
+		}
+
+		return parsed;
+	}
+
 	toObject(tag?: MultiTag, options?: ConvertOptions) {
 		this.standardizeObject(tag, options);
 		const validKeys = getValidKeys(this);
@@ -372,6 +468,11 @@ export class Common<T = string, I extends IdType = IdType> implements ICommon<
 					| ({ value?: string } & Record<string, unknown>)
 			  >
 		> = {};
+
+		// Serialize refType so that fromObject can restore .ref pointer resolution
+		if (this.refType !== undefined) {
+			json._refType = this.refType;
+		}
 
 		validKeys.forEach((key) => {
 			if (key === "id" && this.id !== undefined) {
@@ -397,6 +498,40 @@ export class Common<T = string, I extends IdType = IdType> implements ICommon<
 				}
 			}
 		});
+
+		// Include any lazily-stored raw keys that have not been accessed yet.
+		// Parse them now so that they are serialized correctly.
+		if (this._rawObject) {
+			const remainingKeys = Object.keys(this._rawObject) as MultiTag[];
+			for (const rawKey of remainingKeys) {
+				if (rawKey === "id" || rawKey === "value") {
+					continue; // already handled above
+				}
+				const parsed = this._parseRawKey(rawKey);
+				if (
+					parsed !== undefined &&
+					typeof parsed.toObject === "function"
+				) {
+					if (parsed instanceof Common) {
+						json[rawKey] = parsed.toObject(rawKey, options);
+					} else {
+						type WithToObject = {
+							toObject: (
+								tag: MultiTag,
+								options?: ConvertOptions
+							) => Record<string, unknown>;
+						};
+						json = {
+							...json,
+							...(parsed as unknown as WithToObject).toObject(
+								rawKey,
+								options
+							),
+						};
+					}
+				}
+			}
+		}
 
 		return json;
 	}
@@ -881,6 +1016,15 @@ export const createProxy = <T extends Common>(target: T): T => {
 			if (prop in t) {
 				return Reflect.get(t, prop, receiver);
 			}
+
+			// Lazy-parse from _rawObject before falling back to ref
+			if (typeof prop === "string" && !isOnlyMainProp(prop)) {
+				const parsed = t.tryParseRaw(prop as MultiTag);
+				if (parsed !== undefined) {
+					return parsed;
+				}
+			}
+
 			if (!isOnlyMainProp(prop)) {
 				const ref = t.ref as T;
 				if (ref && prop in ref) {
@@ -924,11 +1068,16 @@ export const isValidKey = <T>(
 	const prop = get(common, key);
 	return (
 		key !== "_gedcom" &&
+		key !== "_rawObject" &&
 		key !== "_main" &&
 		key !== "_parent" &&
 		key !== "_uniqueId" &&
 		key !== "_refs" &&
 		key !== "_type" &&
+		key !== "refType" &&
+		key !== "cloneOf" &&
+		key !== "clonedBy" &&
+		key !== "isListable" &&
 		(key === "id" ||
 			key === "_id" ||
 			key === "value" ||

--- a/src/classes/gedcom.ts
+++ b/src/classes/gedcom.ts
@@ -17,19 +17,19 @@ import { getVersion } from "../utils/get-product-details";
 
 import { Common, createCommon } from "./common";
 import type { FamType } from "./fam";
-import type { Families } from "./fams";
+import { Families } from "./fams";
 import { CustomTags } from "./indi";
 import type { IndiType } from "./indi";
-import type { Individuals } from "./indis";
+import { Individuals } from "./indis";
 import { List } from "./list";
 import type { ObjeType } from "./obje";
-import type { Objects } from "./objes";
+import { Objects } from "./objes";
 import type { RepoType } from "./repo";
-import type { Repositories } from "./repos";
+import { Repositories } from "./repos";
 import type { SourType } from "./sour";
-import type { Sources } from "./sours";
+import { Sources } from "./sours";
 import type { SubmType } from "./subm";
-import type { Submitters } from "./subms";
+import { Submitters } from "./subms";
 
 export class GedCom extends Common implements IGedcom {
 	tagMembers: Record<string, { tag: Common; indis: Individuals }> = {};
@@ -740,6 +740,102 @@ export class GedCom extends Common implements IGedcom {
 export type GedComType = GedCom & IGedComStructure;
 export const createGedCom = (): GedComType => {
 	return new GedCom();
+};
+
+/**
+ * Mapping of top-level GEDCOM list tag names (as they appear in toObject JSON)
+ * to their corresponding @@ list tag and List constructor.
+ * These are handled specially because they contain multiple items with IDs,
+ * rather than a single nested object.
+ */
+const LIST_TAG_MAP: Record<string, { listTag: ListTag; ctor: new () => List }> =
+	{
+		INDI: { listTag: "@@INDI", ctor: Individuals },
+		FAM: { listTag: "@@FAM", ctor: Families },
+		OBJE: { listTag: "@@OBJE", ctor: Objects },
+		SOUR: { listTag: "@@SOUR", ctor: Sources },
+		REPO: { listTag: "@@REPO", ctor: Repositories },
+		SUBM: { listTag: "@@SUBM", ctor: Submitters },
+	};
+
+/**
+ * Reconstructs a full GedComType from a plain object (produced by toObject/toJson).
+ *
+ * Usage:
+ *   const json = gedcom.toObject();        // or JSON.parse(gedcom.toJson())
+ *   const restored = GedCom.fromObject(json);
+ *
+ * The factory (Common._objectFactory) must be registered before calling this.
+ * It is automatically registered when you import 'common-creator.ts' (which the
+ * parser already does), so in normal usage it will always be available.
+ */
+export const gedcomFromObject = (obj: Record<string, unknown>): GedComType => {
+	const gedcom = createGedCom();
+	const factory = Common._objectFactory;
+
+	if (!factory) {
+		throw new Error(
+			"Common._objectFactory is not registered. " +
+				"Import 'utils/common-creator' before calling gedcomFromObject."
+		);
+	}
+
+	// Collect non-list keys for lazy parsing via fromObject
+	const rawNonList: Record<string, unknown> = {};
+
+	for (const [key, rawValue] of Object.entries(obj)) {
+		if (rawValue === undefined || rawValue === null) {
+			continue;
+		}
+
+		const listConfig = LIST_TAG_MAP[key];
+
+		if (listConfig) {
+			// This is a top-level list (INDI, FAM, OBJE, etc.)
+			const { listTag, ctor } = listConfig;
+			const list = new ctor();
+			const items = Array.isArray(rawValue) ? rawValue : [rawValue];
+
+			items.forEach((rawItem: unknown) => {
+				if (!rawItem || typeof rawItem !== "object") {
+					return;
+				}
+				const raw = rawItem as Record<string, unknown>;
+				const id = raw.id as IdType | undefined;
+				if (!id) {
+					return;
+				}
+
+				// Use the factory to build the typed Common instance
+				const node = factory(
+					key as MultiTag,
+					rawItem,
+					gedcom,
+					gedcom as unknown as Common,
+					gedcom as unknown as Common
+				);
+
+				if (node instanceof Common) {
+					// Ensure the gedcom reference is set correctly
+					node.setGedcom(gedcom);
+					list.item(id, node);
+				}
+			});
+
+			// Attach the list to the gedcom object under its @@ tag
+			gedcom.set(listTag as unknown as MultiTag, list);
+		} else {
+			// HEAD, _IS_PURGED, etc. → lazy parsed on first access
+			rawNonList[key] = rawValue;
+		}
+	}
+
+	// Register all non-list keys for lazy parsing
+	if (Object.keys(rawNonList).length > 0) {
+		(gedcom as unknown as Common).fromObject(rawNonList);
+	}
+
+	return gedcom;
 };
 
 export const isGedcomString = (gedcomString?: string) => {

--- a/src/utils/common-creator.ts
+++ b/src/utils/common-creator.ts
@@ -1,10 +1,11 @@
-import { createCommon } from "../classes/common";
-import type { Common } from "../classes/common";
+import { Common, createCommon } from "../classes/common";
+import type { RawObjectFactory } from "../classes/common";
 import { createCommonDate } from "../classes/date";
 import { createFam } from "../classes/fam";
 import { GedCom } from "../classes/gedcom";
 import type { GedComType } from "../classes/gedcom";
 import { createIndi, Indi } from "../classes/indi";
+import { List } from "../classes/list";
 import { createCommonName } from "../classes/name";
 import { createCommonNote } from "../classes/note";
 import { createObje } from "../classes/obje";
@@ -22,6 +23,128 @@ import type {
 	IndiKey,
 	FamKey,
 } from "../types/types";
+
+/**
+ * Creates a single Common instance from a raw plain object entry (from toObject output).
+ * Handles id/value fields and recursively calls fromObject for nested entries.
+ */
+const createCommonFromRaw = (
+	tag: MultiTag,
+	raw: Record<string, unknown>,
+	gedcom?: GedComType,
+	main?: Common,
+	parent?: Common
+): Common => {
+	const id = raw.id as IdType | undefined;
+	const node = createTypedCommon(tag, id, gedcom, main, parent);
+	node.fromObject(raw);
+	return node;
+};
+
+/**
+ * Instantiates the correct class for a given tag (with optional id).
+ * Mirrors the logic in `create()` but without parser-level side effects.
+ */
+const createTypedCommon = (
+	tag: MultiTag,
+	id: IdType | undefined,
+	gedcom: GedComType | undefined,
+	main: Common | undefined,
+	parent: Common | undefined
+): Common => {
+	const convertType = tag as ConvertType;
+	let node: Common;
+
+	if (!gedcom) {
+		return createCommon(undefined, id, main, parent);
+	}
+
+	if (id) {
+		if (convertType === "REPO") {
+			node = createRepo(gedcom, id as RepoKey);
+		} else if (convertType === "SUBM") {
+			node = createSubm(gedcom, id as SubmKey);
+		} else if (convertType === "SOUR") {
+			node = createSour(gedcom, id as SourKey);
+		} else if (convertType === "OBJE") {
+			node = createObje(gedcom, id as ObjeKey);
+		} else if (convertType === "INDI" || convertType === "_INDI") {
+			node = createIndi(gedcom, id as IndiKey);
+		} else if (convertType === "FAM") {
+			node = createFam(gedcom, id as FamKey);
+		} else {
+			node = createCommon(gedcom, id);
+		}
+	} else {
+		if (tag === "REPO") {
+			node = createRepo(gedcom, undefined, main, parent);
+		} else if (tag === "SUBM") {
+			node = createSubm(gedcom, undefined, main, parent);
+		} else if (tag === "SOUR") {
+			node = createSour(gedcom, undefined, main, parent);
+		} else if (tag === "OBJE") {
+			node = createObje(gedcom, undefined, main, parent);
+		} else if (tag === "DATE") {
+			node = createCommonDate(gedcom, undefined, main, parent);
+		} else if (tag === "NOTE") {
+			node = createCommonNote(gedcom, undefined, main, parent);
+		} else if (tag === "NAME" && main instanceof Indi) {
+			node = createCommonName(gedcom, undefined, main, parent);
+		} else {
+			node = createCommon(gedcom, undefined, main, parent);
+		}
+	}
+
+	node.type = tag;
+	return node;
+};
+
+/**
+ * The injectable factory registered on Common._objectFactory.
+ * Converts a raw plain-object value (from toObject) back into a Common or List instance.
+ *
+ * - Array of objects → List of Common instances
+ * - Single object    → one Common instance
+ * - Primitive        → a bare Common with just .value set
+ */
+const rawObjectFactory: RawObjectFactory = (
+	tag,
+	rawValue,
+	gedcom,
+	main,
+	parent
+): Common | List | undefined => {
+	if (rawValue === undefined || rawValue === null) {
+		return undefined;
+	}
+
+	// Array → List (multiple siblings with the same tag)
+	if (Array.isArray(rawValue)) {
+		const list = new List();
+		rawValue.forEach((item, index) => {
+			const child = rawObjectFactory(tag, item, gedcom, main, parent);
+			if (child instanceof Common) {
+				const key = (child.id ?? `${index}`) as IdType;
+				list.item(key, child);
+			}
+		});
+		return list;
+	}
+
+	// Plain object → recurse into it as a Common
+	if (typeof rawValue === "object") {
+		const raw = rawValue as Record<string, unknown>;
+		return createCommonFromRaw(tag, raw, gedcom, main, parent);
+	}
+
+	// Primitive (string / number / boolean) → bare Common with value
+	const node = createTypedCommon(tag, undefined, gedcom, main, parent);
+	node.value = String(rawValue);
+	return node;
+};
+
+// Register the factory once so Common can use it without importing this module
+Common._objectFactory = rawObjectFactory;
 
 export const create = (
 	gedcom: GedComType,


### PR DESCRIPTION
…d restore refType

- Add _rawObject flush block in toObject() to serialize lazily-stored keys
- Use shallow copy in fromObject() to prevent mutation of caller's object
- Serialize refType as _refType in toObject() so .ref resolves after fromObject
- Exclude refType, cloneOf, clonedBy, isListable from isValidKey()
- Register rawObjectFactory on Common._objectFactory in common-creator.ts
- Add gedcomFromObject() to gedcom.ts for full GedCom reconstruction
- Add 22 round-trip tests in from-object.test.ts covering lazy parsing, Common/GedCom round-trips, refType resolution, and class instance checks"